### PR TITLE
switch to sassc-rails

### DIFF
--- a/lib/sudo_rails.rb
+++ b/lib/sudo_rails.rb
@@ -2,6 +2,7 @@ require "sudo_rails/version"
 require "sudo_rails/controller_ext"
 require "sudo_rails/styling"
 require "sudo_rails/engine"
+require "sassc-rails"
 
 module SudoRails
   class << self

--- a/sudo_rails.gemspec
+++ b/sudo_rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "rails", ">= 4.2"
-  spec.add_dependency "sass-rails"
+  spec.add_dependency "sassc-rails"
 
   spec.add_development_dependency "rspec-rails"
 end


### PR DESCRIPTION
Ruby Sass is deprecated, let's switch to SassC!

I think it makes sense, after all, the new `sass-rails` (now in beta) is just a wrapper for `sassc-rails` to allow a smooth upgrades: https://github.com/rails/sass-rails/pull/424. See also: https://github.com/rails/rails/pull/36325#issuecomment-494774687