### PR TITLE
Add alert for incorrect password

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Using the `custom_logo`, `primary_color` and `background_color` options, you can
 
 See some [examples here](support/images/).
 
+**NOTE:** If you are using your own layout, don't forget to show the flash alert. You can do something like [this](app/views/sudo_rails/_flash_alert.html.erb).
+
 ### Confirmation strategy
 
 You should define how to validate the password using the `confirm_strategy` option. It must be a `lambda`, which will receive 2 arguments: the controller instance (`context`) and the password from the user.

--- a/app/assets/stylesheets/sudo_rails/application.scss
+++ b/app/assets/stylesheets/sudo_rails/application.scss
@@ -2,7 +2,7 @@ body {
   text-align: center;
   font-family: Helvetica, Arial, sans-serif;
   background-color: #ececec;
-  transform: translateY(20%);
+  margin: 0 auto;
 }
 
 a {
@@ -11,6 +11,10 @@ a {
 
 input {
   -webkit-appearance: none;
+}
+
+.container {
+  transform: translateY(20%);
 }
 
 .sudo-header {
@@ -54,4 +58,10 @@ input {
 .sudo-tip {
   margin-top: 2em;
   font-size: 14px;
+}
+
+.alert {
+  background: #000;
+  color: #fff;
+  padding: 10px;
 }

--- a/app/controllers/sudo_rails/application_controller.rb
+++ b/app/controllers/sudo_rails/application_controller.rb
@@ -7,7 +7,7 @@ module SudoRails
         session[:sudo_session] = Time.zone.now.to_s
       end
 
-      redirect_to params[:target_path]
+      redirect_to params[:target_path], alert: params[:alert]
     end
 
     private

--- a/app/controllers/sudo_rails/application_controller.rb
+++ b/app/controllers/sudo_rails/application_controller.rb
@@ -5,9 +5,11 @@ module SudoRails
     def confirm
       if request.post? && SudoRails.confirm?(self, params[:password])
         session[:sudo_session] = Time.zone.now.to_s
+      else
+        flash[:alert] = I18n.t('sudo_rails.invalid_pass')
       end
 
-      redirect_to params[:target_path], alert: params[:alert]
+      redirect_to params[:target_path]
     end
 
     private

--- a/app/views/layouts/sudo_rails/application.html.erb
+++ b/app/views/layouts/sudo_rails/application.html.erb
@@ -7,6 +7,9 @@
   <%= render 'sudo_rails/inject_custom_styles' if SudoRails.custom_styles? %>
 </head>
 <body>
-  <%= yield %>
+  <%= render 'sudo_rails/flash_alert' %>
+  <div class="container">
+    <%= yield %>
+  </div>
 </body>
 </html>

--- a/app/views/sudo_rails/_flash_alert.html.erb
+++ b/app/views/sudo_rails/_flash_alert.html.erb
@@ -1,0 +1,5 @@
+<% if flash[:alert].present? %>
+  <div class="alert">
+    <span><%= flash[:alert] %></span>
+  </div>
+<% end %>

--- a/app/views/sudo_rails/_inject_custom_styles.html.erb
+++ b/app/views/sudo_rails/_inject_custom_styles.html.erb
@@ -4,6 +4,11 @@
       background-color: <%= SudoRails.background_color %>;
       color: <%= SudoRails.color_contrast(SudoRails.background_color) %>;
     }
+
+    .alert {
+      background-color: <%= SudoRails.color_contrast(SudoRails.background_color) %>;
+      color: <%= SudoRails.background_color %>;
+    }
   <% end %>
 
   <% if SudoRails.primary_color.present? %>

--- a/app/views/sudo_rails/confirm_form.html.erb
+++ b/app/views/sudo_rails/confirm_form.html.erb
@@ -9,7 +9,6 @@
 <div class='sudo-form'>
   <%= form_tag '/sudo_rails/confirm' do |f| %>
     <%= hidden_field_tag :target_path, params[:target_path] || request.url %>
-    <%= hidden_field_tag :alert, params[:alert] %>
     <%= password_field_tag :password, nil, required: true, placeholder: t('sudo_rails.password') %>
     <%= submit_tag t('sudo_rails.button') %>
   <% end %>

--- a/app/views/sudo_rails/confirm_form.html.erb
+++ b/app/views/sudo_rails/confirm_form.html.erb
@@ -9,6 +9,7 @@
 <div class='sudo-form'>
   <%= form_tag '/sudo_rails/confirm' do |f| %>
     <%= hidden_field_tag :target_path, params[:target_path] || request.url %>
+    <%= hidden_field_tag :alert, params[:alert] %>
     <%= password_field_tag :password, nil, required: true, placeholder: t('sudo_rails.password') %>
     <%= submit_tag t('sudo_rails.button') %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
     button: Confirm password
     password: Password
     forgot_pass: Forgot your password?
+    invalid_pass: Invalid password
     tip: |-
       You are entering <b>sudo mode</b>.<br>
       We won’t ask for your password again for <i>%{session_duration}</i>.


### PR DESCRIPTION
With this PR, we are adding support for an alert message in case the password is wrong. 

Default:
![Screenshot_2020-12-01 Confirm your password to continue](https://user-images.githubusercontent.com/18515893/100766505-00e7da00-33f9-11eb-8e37-c653407f18fa.png)

Custom colors:
![Screenshot_2020-12-01 Confirm your password to continue(1)](https://user-images.githubusercontent.com/18515893/100766499-fdece980-33f8-11eb-867c-345c2247b8b0.png)