### PR TITLE
[Readme] Adding warning to order Gemfile gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ You should define how to validate the password using the `confirm_strategy` opti
 
 By default, the gem ships with `Devise` and `Clearance` integration. Check it [here](lib/sudo_rails/integrations/).
 
+:warning: In order to autoload `Devise` or `Clearance` strategy propertly, place `sudo_rails` gem after it at the Gemfile.
+
 Implementation examples:
 
 ```ruby


### PR DESCRIPTION
**Context**: When you install `Devise` or `Clearance` and your `sudo_rails` gem is above those gems in the Gemfile, the `SudoRails` strategy for those gems will not be loaded automatically. 

**Solution**: You need to place `sudo_rails` gem after them in the Gemfile.